### PR TITLE
update Preparation section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ We get the multi-level multi-scale feature, and try to re-allocate a weight for 
 
 ```Shell
 conda install pytorch torchvision -c pytorch
-pip install opencv-python,tqdm
+pip install opencv-python tqdm
 ```
 - Clone this repository.
 ```Shell

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ We get the multi-level multi-scale feature, and try to re-allocate a weight for 
 - Install deeplearning framework, i.e., pytorch, torchvision and other libs.
 
 ```Shell
-conda install pytorch torchvision -c pytorch
+conda install pytorch==0.4.1 torchvision -c pytorch
 pip install opencv-python tqdm
 ```
 - Clone this repository.


### PR DESCRIPTION
Due to the comma in the bash snippet, the installation with pip failed. 
So that I updated the README.

And I also found that, the snippet `conda install pytorch torchvision -c pytorch` doesn't satisfy the precondition of  **supported version is pytorch-0.4.1**.
So the version fix is also added.